### PR TITLE
Fix log level to be configurable from gulpfile

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,7 @@ var HawtioBackend;
     HawtioBackend.addStartupTask = addStartupTask;
     function setConfig(newConfig) {
         _.assign(config, newConfig);
+        HawtioBackend.log.setLevel(config.logLevel);
     }
     HawtioBackend.setConfig = setConfig;
     var server = null;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "name": "Stan Lewis",
     "email": "gashcrumb@gmail.com"
   },
-  "license": "ASL 2.0",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:hawtio/hawtio-node-backend.git"

--- a/src/init.ts
+++ b/src/init.ts
@@ -31,6 +31,7 @@ module HawtioBackend {
 
   export function setConfig(newConfig:any) {
     _.assign(config, newConfig);
+    log.setLevel(config.logLevel);
   }
   
   var server = null;


### PR DESCRIPTION
Contrary to `README.md`, currently `logLevel` is not configurable from `gulpfile.js`.  This fixes the issue plus adjusts license expression to get rid of a npm warning.